### PR TITLE
Add initial README file for TeamCode Kotlin directory

### DIFF
--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/readme.md
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/readme.md
@@ -1,0 +1,16 @@
+# TeamCode
+
+This directory contains the team's robot code for the FTC season.
+
+## Structure
+
+- **kotlin/**
+- **java/**
+
+## Usage
+
+Add your autonomous and teleop programs in the appropriate packages. You can use either Kotlin or Java depending on your preference and team needs.
+
+## Contributing
+
+Follow the team's coding standards and test thoroughly before committing.


### PR DESCRIPTION
This pull request adds a new `readme.md` file to the `TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode` directory to provide documentation for the team's robot codebase. The new README outlines the directory structure, usage instructions, and contribution guidelines, making it easier for team members to understand and contribute to the project. 

Documentation improvements:

* Added a `readme.md` file that describes the purpose of the directory, the structure of the codebase (including `kotlin/` and `java/` folders), instructions for adding programs, and team contribution guidelines.