### PR TITLE
uses final vars for tick offsets in susan. uses int casting after TPR…

### DIFF
--- a/TeamCode/src/main/java/org/pionerds/ftc/teamcode/Hardware/Storage.java
+++ b/TeamCode/src/main/java/org/pionerds/ftc/teamcode/Hardware/Storage.java
@@ -154,11 +154,11 @@ public class Storage {
             hardware.telemetry.addLine("Error updating inventory: " + e.getMessage());
         }
     }
-    private final int INTAKE2_OFFSET = ((1/3 * 360)*((TPR)/360));
-    private final int INTAKE3_OFFSET = ((2/3 * 360)*((TPR)/360));
-    private final int OUTPUT1_OFFSET = (((180 - (0) * 360))*((TPR)/360));
-    private final int OUTPUT2_OFFSET = (((180 + (1/3) * 360))*((TPR)/360));
-    private final int OUTPUT3_OFFSET = (((180 - (1/3) * 360))*((TPR)/360));
+    private final int INTAKE2_OFFSET = (int) ((1.0/3.0 * 360) * ((TPR)/360));
+    private final int INTAKE3_OFFSET = (int) ((2.0/3.0 * 360) * ((TPR)/360));
+    private final int OUTPUT1_OFFSET = (int) (((180 - (0) * 360)) * ((TPR)/360));
+    private final int OUTPUT2_OFFSET = (int) (((180 + (1.0/3.0) * 360)) * ((TPR)/360));
+    private final int OUTPUT3_OFFSET = (int) (((180 - (1.0/3.0) * 360)) * ((TPR)/360));
 
 
     /**

--- a/TeamCode/src/main/java/org/pionerds/ftc/teamcode/Hardware/Storage.java
+++ b/TeamCode/src/main/java/org/pionerds/ftc/teamcode/Hardware/Storage.java
@@ -13,8 +13,8 @@ import com.qualcomm.robotcore.hardware.Servo;
  */
 public class Storage {
     private final int susanVelocityRequest = 300;  // Requested velocity for susan motor
-    private final int gearRatio = 3;       // Gear ratio: (90/30) = 3:1
-    private final int TPR = 288 * gearRatio; // Ticks per revolution after gearing (288 * 3 = 864)
+    private final double gearRatio = (17/9);       // Gear ratio: (17/9) = 3:1
+    private final int TPR = (int) (560 * gearRatio); // Ticks per revolution before gearing (288 TPR FOR CORE HEX MOTOR | 560 TPR for HD HEX MOTOR)
     private final Artifact[] inventory = new Artifact[]{Artifact.EMPTY, Artifact.EMPTY, Artifact.EMPTY};  // Stores what artifact is in each of 3 storage slots
     private Hardware hardware;
     // Servos and motors for storage mechanism
@@ -154,6 +154,12 @@ public class Storage {
             hardware.telemetry.addLine("Error updating inventory: " + e.getMessage());
         }
     }
+    private final int INTAKE2_OFFSET = ((1/3 * 360)*((TPR)/360));
+    private final int INTAKE3_OFFSET = ((2/3 * 360)*((TPR)/360));
+    private final int OUTPUT1_OFFSET = (((180 - (0) * 360))*((TPR)/360));
+    private final int OUTPUT2_OFFSET = (((180 + (1/3) * 360))*((TPR)/360));
+    private final int OUTPUT3_OFFSET = (((180 - (1/3) * 360))*((TPR)/360));
+
 
     /**
      * Rotates the lazy susan to a specified position using the shortest path.
@@ -176,23 +182,22 @@ public class Storage {
         // OUTPUT positions are at 60°, 180°, and 300°
         switch (susanPosition) {
             case INTAKE2:
-                tickOffset = 96; // ((1/3 * 360)*(TPR/360)) = 96 ticks (120 degrees)
+                tickOffset = INTAKE2_OFFSET; // ((1/3 * 360)*((360-TPR)/360)) = 96 ticks (120 degrees)
                 break;
             case INTAKE3:
-                tickOffset = 192; // ((2/3 * 360)*(TPR/360)) = 192 ticks (240 degrees)
+                tickOffset = INTAKE3_OFFSET; // ((2/3 * 360)*((360-TPR)/360)) = 192 ticks (240 degrees)
                 break;
             case OUTPUT1:
-                tickOffset = 144; // (((180 - (0) * 360))*(TPR/360)) = 144 ticks (180 degrees)
+                tickOffset = OUTPUT1_OFFSET; // (((180 - (0) * 360))*((360-TPR)/360)) = 144 ticks (180 degrees)
                 break;
             case OUTPUT2:
-                tickOffset = 240; // (((180 + (1/3) * 360))*(tpr/360)) = 240 ticks (300 degrees)
+                tickOffset = OUTPUT2_OFFSET; // (((180 + (1/3) * 360))*((360-TPR)/360)) = 240 ticks (300 degrees)
                 break;
             case OUTPUT3:
-                tickOffset = 48; // (((180 - (1/3) * 360))*(TPR/360)) = 48 ticks (60 degrees)
+                tickOffset = OUTPUT3_OFFSET; // (((180 - (1/3) * 360))*((360-TPR)/360)) = 48 ticks (60 degrees)
                 break;
         }
         currentSusanPositionEnum = susanPosition;  // Update tracked position
-        tickOffset *= gearRatio;  // Apply gear ratio to get actual motor ticks
 
         // Calculate three possible target positions (previous, current, and next revolution)
         int currentRevolutionTick = revolutions * TPR + tickOffset;      // Target in current revolution
@@ -201,24 +206,24 @@ public class Storage {
 
         // Calculate distances to each possible target
         int distanceBetweenNowAndCurrent = Math.abs(
-            currentRevolutionTick - currentPos
+                currentRevolutionTick - currentPos
         );
         int distanceBetweenNowAndPrevious = Math.abs(
-            lessRevolutionTick - currentPos
+                lessRevolutionTick - currentPos
         );
         int distanceBetweenNowAndNext = Math.abs(
-            moreRevolutionTick - currentPos
+                moreRevolutionTick - currentPos
         );
 
         // Choose the closest target (shortest rotation path)
         if (
-            distanceBetweenNowAndPrevious <= distanceBetweenNowAndCurrent &&
-                distanceBetweenNowAndPrevious <= distanceBetweenNowAndNext
+                distanceBetweenNowAndPrevious <= distanceBetweenNowAndCurrent &&
+                        distanceBetweenNowAndPrevious <= distanceBetweenNowAndNext
         ) {
             susanTargetTicks = lessRevolutionTick;
         } else if (
-            distanceBetweenNowAndCurrent <= distanceBetweenNowAndPrevious &&
-                distanceBetweenNowAndCurrent <= distanceBetweenNowAndNext
+                distanceBetweenNowAndCurrent <= distanceBetweenNowAndPrevious &&
+                        distanceBetweenNowAndCurrent <= distanceBetweenNowAndNext
         ) {
             susanTargetTicks = currentRevolutionTick;
         } else {
@@ -228,7 +233,7 @@ public class Storage {
         // Output debugging information to telemetry
         hardware.telemetry.addLine("\n\n");
         hardware.telemetry.addLine(
-            "susanPosition: " + susanMotorEx.getCurrentPosition()
+                "susanPosition: " + susanMotorEx.getCurrentPosition()
         );
         hardware.telemetry.addLine("susanTarget: " + susanTargetTicks);
         hardware.telemetry.addLine("susanRunMode: " + susanMotorEx.getMode());
@@ -303,7 +308,7 @@ public class Storage {
         if (!output) finalPos = "INPUT1";
 
         String[] positions =
-            {"OUTPUT1", "OUTPUT2", "OUTPUT3"};  // Output positions correspond to inventory indices
+                {"OUTPUT1", "OUTPUT2", "OUTPUT3"};  // Output positions correspond to inventory indices
         if (!output) positions = new String[]{"INPUT1", "INPUT2", "INPUT3"};
 
         // Extract the numeric index from the position name (e.g., "OUTPUT1" -> 0, "INTAKE2" -> 1)
@@ -435,8 +440,8 @@ public class Storage {
 
     public void waitForSusanRotation(){
         while(susanMotorEx.isBusy()){
-        hardware.telemetry.addLine("Suzie Busy...");
-        hardware.telemetry.update();
+            hardware.telemetry.addLine("Suzie Busy...");
+            hardware.telemetry.update();
         }
     }
 


### PR DESCRIPTION
This pull request updates the lazy susan position calculations in the `Storage` class to improve accuracy and maintainability. The main changes include correcting the gear ratio and ticks-per-revolution (`TPR`) calculations, defining position offsets as constants, and refactoring the position logic to use these new constants.

### Hardware configuration updates

* Corrected the `gearRatio` calculation to use `17/9` and updated `TPR` to use the correct value for the HD Hex Motor (`560`), replacing the previous hardcoded values. (`[TeamCode/src/main/java/org/pionerds/ftc/teamcode/Hardware/Storage.javaL16-R17](diffhunk://#diff-6c9a8f79a99c1106120d20033e5806fd2ad2f288d40197a75cf4ac69b34be5eeL16-R17)`)

### Position offset refactoring

* Introduced constants (`INTAKE2_OFFSET`, `INTAKE3_OFFSET`, `OUTPUT1_OFFSET`, `OUTPUT2_OFFSET`, `OUTPUT3_OFFSET`) for lazy susan position offsets, improving code readability and maintainability. (`[TeamCode/src/main/java/org/pionerds/ftc/teamcode/Hardware/Storage.javaR157-R162](diffhunk://#diff-6c9a8f79a99c1106120d20033e5806fd2ad2f288d40197a75cf4ac69b34be5eeR157-R162)`)
* Refactored the `moveSusanTo` method to use the new offset constants instead of hardcoded tick values for each position, ensuring more accurate and consistent movement calculations. (`[TeamCode/src/main/java/org/pionerds/ftc/teamcode/Hardware/Storage.javaL179-L195](diffhunk://#diff-6c9a8f79a99c1106120d20033e5806fd2ad2f288d40197a75cf4ac69b34be5eeL179-L195)`)… calculation.

Please make sure your code is either mostly readable or you can explain it to someone
